### PR TITLE
Update version to 1.12.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY314: yes

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,9 +1,0 @@
-# Encountered problems while solving:
-#   - package rust_osx-arm64-1.89.0-h3d905bd_0 requires clang_osx-arm64 17.*, but none of the providers can be installed
-# Could not solve for environment specs
-# The following packages are incompatible
-# ├─ clang_osx-arm64 =20 * is requested and can be installed;
-# └─ rust_osx-arm64 =1.89.0 * is not installable because it requires
-#    └─ clang_osx-arm64 =17 *, which conflicts with any installable versions previously reported.
-c_compiler_version:  # [osx]
-  - 17               # [osx]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "ormsgpack" %}
-{% set version = "1.11.0" %}
+{% set version = "1.12.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,14 +7,14 @@ package:
 
 source:
   url: https://github.com/aviramha/{{ name }}/archive/refs/tags/{{ version }}.tar.gz
-  sha256: d1c1503124e32c864a16083f7819e2b24a84375f08ecc094478052ea75b69d67
+  sha256: eafeffec299a776a621cce0ef3e58aeeb62ccae555084f8678a71a1cbfcd8585
 
 build:
   number: 0
   script:
     - cargo-bundle-licenses --format yaml --output THIRDPARTY.yml
     - {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  skip: true  # [py<39]
+  skip: true  # [py<310]
   
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "ormsgpack" %}
-{% set version = "1.12.0" %}
+{% set version = "1.12.2" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/aviramha/{{ name }}/archive/refs/tags/{{ version }}.tar.gz
-  sha256: eafeffec299a776a621cce0ef3e58aeeb62ccae555084f8678a71a1cbfcd8585
+  sha256: 58c8803dd833f979645976cf36a521a1036b66dde655abfa163129e9ebbe997f
 
 build:
   number: 0


### PR DESCRIPTION
ormsgpack 1.12.0

**Destination channel:**  defaults

### Links

- [PKG-12052](https://anaconda.atlassian.net/browse/PKG-12052) 
- [Upstream repository](https://github.com/ormsgpack/ormsgpack)

### Explanation of changes:
- New version number
- Build for python 3.14
- Using compiler 20 version for osx


[PKG-12052]: https://anaconda.atlassian.net/browse/PKG-12052?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ